### PR TITLE
add create compatibility recipes

### DIFF
--- a/src/main/resources/data/sulfurpotassiummod/recipes/crushing_potassium.json
+++ b/src/main/resources/data/sulfurpotassiummod/recipes/crushing_potassium.json
@@ -1,0 +1,20 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "sulfurpotassiummod:potassium_ore"
+    }
+  ], 
+"results": [
+  {
+    "item": "sulfurpotassiummod:raw_potassium",
+    "count": 1,
+    "chance": 1
+  },
+  {
+    "item": "sulfurpotassiummod:raw_potassium",
+    "count": 1,
+    "chance": 0.25
+  }
+]
+}

--- a/src/main/resources/data/sulfurpotassiummod/recipes/crushing_sulfur.json
+++ b/src/main/resources/data/sulfurpotassiummod/recipes/crushing_sulfur.json
@@ -1,0 +1,20 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "sulfurpotassiummod:sulfur_ore"
+    }
+  ], 
+"results": [
+  {
+    "item": "sulfurpotassiummod:sulfur",
+    "count": 1,
+    "chance": 1
+  },
+  {
+    "item": "sulfurpotassiummod:sulfur",
+    "count": 1,
+    "chance": 0.75
+  }
+]
+}

--- a/src/main/resources/data/sulfurpotassiummod/recipes/haunting_sulfur.json
+++ b/src/main/resources/data/sulfurpotassiummod/recipes/haunting_sulfur.json
@@ -1,0 +1,15 @@
+{
+  "type": "create:haunting",
+  "ingredients": [
+    {
+      "item": "sulfurpotassiummod:sulfur"
+    }
+  ], 
+"results": [
+  {
+    "item": "minecraft:blaze_powder",
+    "count": 1,
+    "chance": 1
+  }
+]
+}

--- a/src/main/resources/data/sulfurpotassiummod/recipes/milling_sulfur.json
+++ b/src/main/resources/data/sulfurpotassiummod/recipes/milling_sulfur.json
@@ -1,0 +1,15 @@
+{
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "sulfurpotassiummod:sulfur_ore"
+    }
+  ], 
+"results": [
+  {
+    "item": "sulfurpotassiummod:sulfur",
+    "count": 1,
+    "chance": 1
+  }
+]
+}


### PR DESCRIPTION
Change adds recipes for create.  Milling silk touched ores will drop the item forms.  Crushing will do the same, but with a chance for a bonus.  Adds a recipe to convert sulfur into blaze powder via soul fire particles